### PR TITLE
update history peerDependency to 0.16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "warning": "^2.0.0"
   },
   "peerDependencies": {
-    "history": "1.15.x"
+    "history": "1.16.x"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
With history now updated to 0.16, this is breaking react-router's peerDependencies
